### PR TITLE
fix: Correct wildcard search implementation for providers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . .
 RUN make build
 
-FROM busybox:latest@sha256:f85340bf132ae937d2c2a763b8335c9bab35d6e8293f70f606b9c6178d84f42b
+FROM gcr.io/distroless/static-debian12
 
 COPY --from=builder /app/kube-audit-mcp /usr/local/bin/
 

--- a/pkg/provider/alibaba/sls_filter_test.go
+++ b/pkg/provider/alibaba/sls_filter_test.go
@@ -1,0 +1,48 @@
+package alibaba
+
+import (
+	"testing"
+)
+
+func TestGetSLSFilterExp(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyword  string
+		expected string
+	}{
+		{
+			name:     "wildcard suffix",
+			keyword:  "test*",
+			expected: "test*",
+		},
+		{
+			name:     "exact match",
+			keyword:  "test",
+			expected: `"test"`,
+		},
+		{
+			name:     "empty string",
+			keyword:  "",
+			expected: `""`,
+		},
+		{
+			name:     "special characters",
+			keyword:  "test-123",
+			expected: `"test-123"`,
+		},
+		{
+			name:     "multiple wildcards but not at suffix",
+			keyword:  "*test",
+			expected: `"*test"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getSLSFilterExp(tt.keyword)
+			if got != tt.expected {
+				t.Errorf("getSLSFilterExp(%q) = %q, want %q", tt.keyword, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/provider/alibaba/sls_test.go
+++ b/pkg/provider/alibaba/sls_test.go
@@ -35,6 +35,16 @@ func TestSLSProvider_buildQuery(t *testing.T) {
 			expected: `* and user.username: "testuser"`,
 		},
 		{
+			name: "user wildcard",
+			params: types.QueryAuditLogParams{
+				StartTime: types.NewTimeParam(time.Now().Add(-1 * time.Hour)),
+				EndTime:   types.NewTimeParam(time.Now()),
+				User:      "testuser*",
+				Limit:     100,
+			},
+			expected: `* and user.username: testuser*`,
+		},
+		{
 			name: "user wildcard - should be ignored",
 			params: types.QueryAuditLogParams{
 				StartTime: types.NewTimeParam(time.Now().Add(-1 * time.Hour)),
@@ -53,6 +63,16 @@ func TestSLSProvider_buildQuery(t *testing.T) {
 				Limit:     100,
 			},
 			expected: `* and objectRef.namespace: "kube-system"`,
+		},
+		{
+			name: "namespace wildcard",
+			params: types.QueryAuditLogParams{
+				StartTime: types.NewTimeParam(time.Now().Add(-1 * time.Hour)),
+				EndTime:   types.NewTimeParam(time.Now()),
+				Namespace: "kube-*",
+				Limit:     100,
+			},
+			expected: `* and objectRef.namespace: kube-*`,
 		},
 		{
 			name: "namespace wildcard - should be ignored",
@@ -113,6 +133,16 @@ func TestSLSProvider_buildQuery(t *testing.T) {
 				Limit:        100,
 			},
 			expected: `* and objectRef.name: "my-pod"`,
+		},
+		{
+			name: "resource name wildcard",
+			params: types.QueryAuditLogParams{
+				StartTime:    types.NewTimeParam(time.Now().Add(-1 * time.Hour)),
+				EndTime:      types.NewTimeParam(time.Now()),
+				ResourceName: "my-pod*",
+				Limit:        100,
+			},
+			expected: `* and objectRef.name: my-pod*`,
 		},
 		{
 			name: "resource name wildcard - should be ignored",

--- a/pkg/provider/gcp/logging.go
+++ b/pkg/provider/gcp/logging.go
@@ -96,11 +96,16 @@ func (c *CloudLoggingProvider) buildQuery(params types.QueryAuditLogParams) stri
 	}
 
 	if params.User != "" && params.User != "*" {
-		query += fmt.Sprintf(" AND protoPayload.authenticationInfo.principalEmail: %q", params.User)
+		keyword := strings.TrimSuffix(params.User, "*")
+		query += fmt.Sprintf(" AND protoPayload.authenticationInfo.principalEmail: %q", keyword)
 	}
 
 	if params.Namespace != "" && params.Namespace != "*" {
-		query += fmt.Sprintf(` AND protoPayload.resourceName: "/namespaces/%s/"`, params.Namespace)
+		keyword := params.Namespace + "/"
+		if strings.HasSuffix(params.Namespace, "*") {
+			keyword = strings.TrimSuffix(params.Namespace, "*")
+		}
+		query += fmt.Sprintf(` AND protoPayload.resourceName: "/namespaces/%s"`, keyword)
 	}
 
 	if len(params.Verbs) > 0 {
@@ -120,8 +125,11 @@ func (c *CloudLoggingProvider) buildQuery(params types.QueryAuditLogParams) stri
 	}
 
 	if params.ResourceName != "" && params.ResourceName != "*" {
-		query += fmt.Sprintf(" AND protoPayload.resourceName =~ %q",
-			fmt.Sprintf("/%s$", params.ResourceName))
+		keyword := fmt.Sprintf("/%s$", params.ResourceName)
+		if strings.HasSuffix(params.ResourceName, "*") {
+			keyword = fmt.Sprintf("/%s", strings.TrimSuffix(params.ResourceName, "*"))
+		}
+		query += fmt.Sprintf(" AND protoPayload.resourceName =~ %q", keyword)
 	}
 
 	return query

--- a/pkg/provider/gcp/logging_build_query_test.go
+++ b/pkg/provider/gcp/logging_build_query_test.go
@@ -1,0 +1,74 @@
+package gcp
+
+import (
+	"github.com/mozillazg/kube-audit-mcp/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCloudLoggingProvider_buildQuery2(t *testing.T) {
+	type fields struct {
+		client      cloudLoggingProviderClientInterface
+		projectId   string
+		clusterName string
+	}
+	type args struct {
+		params types.QueryAuditLogParams
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "should build a query with a namespace and wildcard",
+			fields: fields{
+				projectId:   "test-project",
+				clusterName: "test-cluster",
+			},
+			args: args{
+				params: types.QueryAuditLogParams{
+					Namespace: "test-namespace*",
+				},
+			},
+			want: `resource.type="k8s_cluster" AND logName="projects/test-project/logs/cloudaudit.googleapis.com%2Factivity" AND resource.labels.cluster_name="test-cluster" AND protoPayload.resourceName: "/namespaces/test-namespace"`,
+		},
+		{
+			name: "should build a query with a resource name and wildcard",
+			fields: fields{
+				projectId:   "test-project",
+				clusterName: "test-cluster",
+			},
+			args: args{
+				params: types.QueryAuditLogParams{
+					ResourceName: "test-resource*",
+				},
+			},
+			want: `resource.type="k8s_cluster" AND logName="projects/test-project/logs/cloudaudit.googleapis.com%2Factivity" AND resource.labels.cluster_name="test-cluster" AND protoPayload.resourceName =~ "/test-resource"`,
+		},
+		{
+			name: "should build a query with a user name and wildcard",
+			fields: fields{
+				projectId:   "test-project",
+				clusterName: "test-cluster",
+			},
+			args: args{
+				params: types.QueryAuditLogParams{
+					User: "test-user*",
+				},
+			},
+			want: `resource.type="k8s_cluster" AND logName="projects/test-project/logs/cloudaudit.googleapis.com%2Factivity" AND resource.labels.cluster_name="test-cluster" AND protoPayload.authenticationInfo.principalEmail: "test-user"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CloudLoggingProvider{
+				client:      tt.fields.client,
+				projectId:   tt.fields.projectId,
+				clusterName: tt.fields.clusterName,
+			}
+			assert.Equalf(t, tt.want, c.buildQuery(tt.args.params), "buildQuery(%v)", tt.args.params)
+		})
+	}
+}

--- a/pkg/tools/query_audit_log.go
+++ b/pkg/tools/query_audit_log.go
@@ -77,7 +77,9 @@ func (t *QueryAuditLogTool) handle(ctx context.Context, req mcp.CallToolRequest)
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	result.Params = input
-	result.Note = auditLogResultNote
+	if len(result.Entries) > 0 {
+		result.Note = auditLogResultNote
+	}
 
 	return mcp.NewToolResultStructuredOnly(result), nil
 }


### PR DESCRIPTION
This commit fixes the wildcard search functionality for both Alibaba Cloud SLS and GCP Cloud Logging providers, which was not working as expected.

Previously, using a trailing asterisk (*) for prefix searches on fields like user, namespace, and resource name did not produce the correct query.

The changes in this commit ensure that:
- For Alibaba Cloud SLS, queries with wildcards are now correctly formatted.
- For GCP Cloud Logging, the query logic is adjusted to properly handle wildcard characters.

Unit tests have been added and updated to verify the corrected behavior and prevent future regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added wildcard support for User, Namespace, and Resource Name filters in audit log queries for Alibaba and GCP providers.

- Bug Fixes
  - Display the result note only when entries are found, reducing unnecessary output.

- Chores
  - Switched the runtime container base image to a distroless Debian 12 for a slimmer, more secure image.

- Tests
  - Introduced comprehensive unit tests covering wildcard scenarios for both Alibaba and GCP query builders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->